### PR TITLE
Fix for MongoDB v3.2> "Unknown modifier: $pushAll" error retrieved.

### DIFF
--- a/models/blog.js
+++ b/models/blog.js
@@ -108,6 +108,8 @@ const blogSchema = new Schema({
     comment: { type: String, validate: commentValidators },
     commentator: { type: String }
   }]
+}, {
+  usePushEach: true
 });
 
 // Export Module/Schema

--- a/models/user.js
+++ b/models/user.js
@@ -134,6 +134,8 @@ const userSchema = new Schema({
   email: { type: String, required: true, unique: true, lowercase: true, validate: emailValidators },
   username: { type: String, required: true, unique: true, lowercase: true, validate: usernameValidators },
   password: { type: String, required: true, validate: passwordValidators }
+}, {
+  usePushEach: true
 });
 
 // Schema Middleware to Encrypt Password


### PR DESCRIPTION
Latest versions of MongoDB (above 3.2) have deprecated `$pushAll` modifier. MongoDB team at least gave us workaround for that, so anyone using somewhat newer mongo, should consider adding this configuration to the Schema.